### PR TITLE
Add database schema, configuration, and seeders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+/vendor/
+/.env
+/uploads/
+/.idea
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # iswift
+
+## Setup
+1. Run database schema:
+   `mysql -u <user> -p < database/schema.sql`
+2. Edit `config.php` and update database credentials.
+3. Run seeders:
+   `php admin/seed_create_admin.php`
+   `php admin/seed_sample_products.php`
+
+Next steps: admin login/auth pages and dashboard.

--- a/admin/seed_create_admin.php
+++ b/admin/seed_create_admin.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/db.php';
+
+// Seeder inputs (TODO: change for production)
+$email = 'admin@iswift.in';
+$name  = 'Super Admin';
+$pass  = 'Admin@123';
+
+try {
+    $pdo = db();
+
+    $stmt = $pdo->prepare('SELECT id FROM admins WHERE email = ? LIMIT 1');
+    $stmt->execute([$email]);
+    if ($stmt->fetch()) {
+        echo "Admin already exists: {$email}\n";
+        exit;
+    }
+
+    $stmt = $pdo->prepare('INSERT INTO admins (name, email, password_hash, status, created_at, updated_at) VALUES (?, ?, ?, ?, NOW(), NOW())');
+    $stmt->execute([
+        $name,
+        $email,
+        password_hash($pass, PASSWORD_DEFAULT),
+        'active'
+    ]);
+
+    echo "Admin created: {$email}\n";
+} catch (PDOException $e) {
+    echo 'Error: ' . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/admin/seed_sample_products.php
+++ b/admin/seed_sample_products.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../lib/db.php';
+
+$products = [
+    [
+        'title' => 'iSwift Smart Lock',
+        'slug' => 'iswift-smart-lock',
+        'sku' => 'SL-001',
+        'short_desc' => 'Sample smart lock.',
+        'description' => 'Sample description for smart lock.',
+        'price' => 5000.00,
+        'sale_price' => 4500.00,
+        'is_featured' => 1,
+        'category_slug' => 'smart-locks',
+        'images' => [
+            ['url' => '/uploads/products/sample1.jpg', 'alt_text' => 'Smart Lock - Front'],
+            ['url' => '/uploads/products/sample1b.jpg', 'alt_text' => 'Smart Lock - Side'],
+        ],
+    ],
+    [
+        'title' => 'iSwift Video Door Phone',
+        'slug' => 'iswift-video-door-phone',
+        'sku' => 'VDP-001',
+        'short_desc' => 'Sample video door phone.',
+        'description' => 'Sample description for video door phone.',
+        'price' => 8000.00,
+        'sale_price' => 7500.00,
+        'is_featured' => 1,
+        'category_slug' => 'video-door-phones',
+        'images' => [
+            ['url' => '/uploads/products/sample2.jpg', 'alt_text' => 'Video Door Phone - Front'],
+            ['url' => '/uploads/products/sample2b.jpg', 'alt_text' => 'Video Door Phone - Screen'],
+        ],
+    ],
+];
+
+try {
+    $pdo = db();
+    $pdo->beginTransaction();
+
+    foreach ($products as $p) {
+        $stmt = $pdo->prepare('SELECT id FROM products WHERE slug = ? LIMIT 1');
+        $stmt->execute([$p['slug']]);
+        if ($stmt->fetch()) {
+            continue; // product already exists
+        }
+
+        $stmtCat = $pdo->prepare('SELECT id FROM categories WHERE slug = ? LIMIT 1');
+        $stmtCat->execute([$p['category_slug']]);
+        $cat = $stmtCat->fetch();
+        $categoryId = $cat['id'] ?? null;
+
+        $stmt = $pdo->prepare('INSERT INTO products (title, slug, sku, short_desc, description, price, sale_price, is_featured, is_active, category_id, meta_title, meta_desc, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?, ?, NOW(), NOW())');
+        $stmt->execute([
+            $p['title'],
+            $p['slug'],
+            $p['sku'],
+            $p['short_desc'],
+            $p['description'],
+            $p['price'],
+            $p['sale_price'],
+            $p['is_featured'],
+            $categoryId,
+            $p['title'],
+            $p['short_desc'],
+        ]);
+        $productId = (int)$pdo->lastInsertId();
+
+        $stmtImg = $pdo->prepare('INSERT INTO product_images (product_id, url, alt_text, sort_order, created_at) VALUES (?, ?, ?, ?, NOW())');
+        $sort = 0;
+        foreach ($p['images'] as $img) {
+            $stmtImg->execute([$productId, $img['url'], $img['alt_text'], $sort++]);
+        }
+    }
+
+    $pdo->commit();
+    echo "Sample products seeding completed.\n";
+} catch (PDOException $e) {
+    if ($pdo->inTransaction()) {
+        $pdo->rollBack();
+    }
+    echo 'Error: ' . $e->getMessage() . "\n";
+    exit(1);
+}

--- a/config.php
+++ b/config.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types=1);
+
+// Application environment: local or production
+if (!defined('APP_ENV')) {
+    define('APP_ENV', 'local');
+}
+
+// Database configuration
+if (!defined('DB_HOST')) {
+    define('DB_HOST', '127.0.0.1');
+}
+if (!defined('DB_PORT')) {
+    define('DB_PORT', 3306);
+}
+if (!defined('DB_NAME')) {
+    define('DB_NAME', 'iswift_db');
+}
+if (!defined('DB_USER')) {
+    define('DB_USER', 'your_db_user'); // TODO: change to real DB user
+}
+if (!defined('DB_PASS')) {
+    define('DB_PASS', 'your_db_password'); // TODO: change to real DB password
+}
+
+// Session configuration
+if (!defined('SESSION_NAME')) {
+    define('SESSION_NAME', 'iswift_admin');
+}
+if (!defined('SESSION_LIFETIME')) {
+    define('SESSION_LIFETIME', 7200); // 2 hours
+}
+
+// CSRF token key
+if (!defined('CSRF_TOKEN_KEY')) {
+    define('CSRF_TOKEN_KEY', 'iswift_csrf');
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,0 +1,86 @@
+CREATE DATABASE IF NOT EXISTS iswift_db DEFAULT CHARSET utf8mb4 COLLATE utf8mb4_unicode_ci;
+USE iswift_db;
+
+-- Table: admins
+CREATE TABLE IF NOT EXISTS admins (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    password_hash VARCHAR(255) NOT NULL,
+    status ENUM('active','disabled') DEFAULT 'active',
+    last_login_at DATETIME NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: categories
+CREATE TABLE IF NOT EXISTS categories (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL UNIQUE,
+    sort_order INT DEFAULT 0,
+    is_active TINYINT(1) DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: products
+CREATE TABLE IF NOT EXISTS products (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(255) NOT NULL,
+    slug VARCHAR(255) NOT NULL UNIQUE,
+    sku VARCHAR(100) NOT NULL,
+    short_desc VARCHAR(500) NULL,
+    description MEDIUMTEXT NULL,
+    price DECIMAL(12,2) NOT NULL,
+    sale_price DECIMAL(12,2) NULL,
+    is_featured TINYINT(1) DEFAULT 0,
+    is_active TINYINT(1) DEFAULT 1,
+    category_id INT UNSIGNED NULL,
+    meta_title VARCHAR(255) NULL,
+    meta_desc VARCHAR(500) NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    INDEX idx_category_id (category_id),
+    INDEX idx_is_active (is_active),
+    CONSTRAINT fk_products_category FOREIGN KEY (category_id) REFERENCES categories(id) ON UPDATE CASCADE ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: product_images
+CREATE TABLE IF NOT EXISTS product_images (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    product_id INT UNSIGNED NOT NULL,
+    url VARCHAR(500) NOT NULL,
+    alt_text VARCHAR(255) NULL,
+    sort_order INT DEFAULT 0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_product_id (product_id),
+    CONSTRAINT fk_product_images_product FOREIGN KEY (product_id) REFERENCES products(id) ON UPDATE CASCADE ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Table: inquiries
+CREATE TABLE IF NOT EXISTS inquiries (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    source ENUM('contact','product','other') DEFAULT 'contact',
+    product_id INT UNSIGNED NULL,
+    name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NULL,
+    phone VARCHAR(50) NULL,
+    message TEXT NULL,
+    status ENUM('new','in_progress','closed') DEFAULT 'new',
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_inquiries_product FOREIGN KEY (product_id) REFERENCES products(id) ON UPDATE CASCADE ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Seed starter categories
+INSERT INTO categories (name, slug)
+SELECT * FROM (SELECT 'Smart Locks' AS name, 'smart-locks' AS slug) AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM categories WHERE slug='smart-locks');
+
+INSERT INTO categories (name, slug)
+SELECT * FROM (SELECT 'Video Door Phones' AS name, 'video-door-phones' AS slug) AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM categories WHERE slug='video-door-phones');
+
+INSERT INTO categories (name, slug)
+SELECT * FROM (SELECT 'Smart Curtains' AS name, 'smart-curtains' AS slug) AS tmp
+WHERE NOT EXISTS (SELECT 1 FROM categories WHERE slug='smart-curtains');

--- a/lib/db.php
+++ b/lib/db.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+
+/**
+ * Obtain a singleton PDO connection.
+ */
+function db(): PDO
+{
+    static $pdo = null;
+
+    if ($pdo === null) {
+        $dsn = 'mysql:host=' . DB_HOST . ';port=' . DB_PORT . ';dbname=' . DB_NAME . ';charset=utf8mb4';
+        $options = [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
+            PDO::ATTR_EMULATE_PREPARES => false,
+        ];
+        $pdo = new PDO($dsn, DB_USER, DB_PASS, $options);
+    }
+
+    return $pdo;
+}

--- a/lib/session.php
+++ b/lib/session.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+
+/**
+ * Start application session with custom parameters.
+ */
+function start_app_session(): void
+{
+    if (session_status() === PHP_SESSION_ACTIVE) {
+        return;
+    }
+
+    $secure = !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off';
+
+    session_name(SESSION_NAME);
+    session_set_cookie_params([
+        'lifetime' => SESSION_LIFETIME,
+        'path' => '/',
+        'secure' => $secure,
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ]);
+
+    session_start();
+}


### PR DESCRIPTION
## Summary
- define MySQL schema for admins, categories, products, product images, and inquiries
- add configuration, database connection, and session helper
- provide admin and product seeder scripts

## Testing
- `php -l config.php`
- `php -l lib/db.php`
- `php -l lib/session.php`
- `php -l admin/seed_create_admin.php`
- `php -l admin/seed_sample_products.php`
- `php -r "require 'lib/db.php'; echo db()->query('SELECT 1')->fetchColumn();"` *(fails: SQLSTATE[HY000] [2002] Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_689b2055d1888332add528f11a2290d6