### PR TITLE
Add core admin module with authentication and CRUD

### DIFF
--- a/admin/_inc/auth_guard.php
+++ b/admin/_inc/auth_guard.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+
+start_app_session();
+
+if (empty($_SESSION['admin'])) {
+    redirect('/admin/login.php');
+}
+
+$current_admin = $_SESSION['admin'];
+
+function require_admin(): array
+{
+    global $current_admin;
+    return $current_admin;
+}

--- a/admin/_inc/footer.php
+++ b/admin/_inc/footer.php
@@ -1,0 +1,6 @@
+</main>
+<footer style="text-align:center;padding:20px;color:var(--text-muted);">
+    &copy; <?php echo date('Y'); ?> iSwift
+</footer>
+</body>
+</html>

--- a/admin/_inc/header.php
+++ b/admin/_inc/header.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/auth_guard.php';
+$admin = require_admin();
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>iSwift Admin</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/admin/assets/admin.css">
+</head>
+<body>
+<header>
+    <div><strong>iSwift Admin</strong></div>
+    <nav>
+        <a href="/admin/index.php">Dashboard</a>
+        <a href="/admin/products/list.php">Products</a>
+        <a href="/admin/inquiries/list.php">Inquiries</a>
+        <a href="/admin/account/change_password.php">Account</a>
+        <a href="/admin/logout.php">Logout (<?php echo e($admin['name']); ?>)</a>
+    </nav>
+</header>
+<main style="padding:20px;">

--- a/admin/account/change_password.php
+++ b/admin/account/change_password.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+$admin = require_admin();
+$errors=[];
+
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    verify_csrf();
+    $current = input('current_password');
+    $new = input('new_password');
+    $confirm = input('confirm_password');
+    if($new!==$confirm) $errors['confirm']='Passwords do not match';
+    if(strlen($new)<8 || !preg_match('/[A-Za-z]/',$new) || !preg_match('/\d/',$new)) $errors['new']='Password must be 8 chars with letters and digits';
+    // verify current
+    $stmt=db()->prepare('SELECT password_hash FROM admins WHERE id=?');
+    $stmt->execute([$admin['id']]);
+    $hash=$stmt->fetchColumn();
+    if(!$hash || !password_verify($current,$hash)) $errors['current']='Current password incorrect';
+    if(!$errors){
+        $newHash=password_hash($new,PASSWORD_DEFAULT);
+        db()->prepare('UPDATE admins SET password_hash=? WHERE id=?')->execute([$newHash,$admin['id']]);
+        flash_set('success','Password updated');
+    }
+}
+
+include __DIR__ . '/../_inc/header.php';
+?>
+<h2>Change Password</h2>
+<?php if($msg=flash_get('success')): ?><p class="card"><?php echo $msg; ?></p><?php endif; ?>
+<form method="post" class="card">
+<?php echo csrf_field(); ?>
+<label>Current Password
+<input type="password" name="current_password" required>
+<?php if(!empty($errors['current'])) echo '<div class="form-error">'.e($errors['current']).'</div>'; ?>
+</label>
+<label>New Password
+<input type="password" name="new_password" required>
+<?php if(!empty($errors['new'])) echo '<div class="form-error">'.e($errors['new']).'</div>'; ?>
+</label>
+<label>Confirm Password
+<input type="password" name="confirm_password" required>
+<?php if(!empty($errors['confirm'])) echo '<div class="form-error">'.e($errors['confirm']).'</div>'; ?>
+</label>
+<input type="submit" value="Change">
+</form>
+<?php include __DIR__ . '/../_inc/footer.php';

--- a/admin/assets/admin.css
+++ b/admin/assets/admin.css
@@ -1,0 +1,47 @@
+:root {
+    --bg-light:#FFF8F0;
+    --accent-orange:#FF6F40;
+    --accent-red:#E25822;
+    --accent-yellow:#FFD447;
+    --btn-bg:#FFB347;
+    --btn-text:#3B1F0F;
+    --text-muted:#5A4033;
+    --card-bg:#FFF1E5;
+    --shadow:rgba(255,111,64,.2);
+    font-family: 'Inter', sans-serif;
+}
+body {
+    background: var(--bg-light);
+    margin:0;
+    color:#333;
+}
+a {color:var(--accent-orange); text-decoration:none;}
+a:hover{ text-decoration:underline;}
+header {
+    background: var(--card-bg);
+    box-shadow:0 2px 4px var(--shadow);
+    padding:10px 20px;
+    display:flex;
+    justify-content:space-between;
+    align-items:center;
+}
+nav a {margin-right:15px;}
+.button,button,input[type="submit"]{
+    background:var(--btn-bg);
+    color:var(--btn-text);
+    border:none;
+    padding:8px 14px;
+    border-radius:6px;
+    cursor:pointer;
+    transition:transform .1s;
+}
+button:hover,input[type="submit"]:hover,.button:hover{transform:scale(1.05);}
+.card{background:var(--card-bg);padding:15px;border-radius:8px;box-shadow:0 2px 4px var(--shadow);margin-bottom:20px;}
+.table{width:100%;border-collapse:collapse;}
+.table th,.table td{padding:8px;border-bottom:1px solid #ddd;text-align:left;}
+.table th{background:var(--card-bg);}
+input[type="text"],input[type="email"],input[type="password"],textarea,select{
+    width:100%;padding:8px;border:1px solid #ccc;border-radius:6px;margin-bottom:10px;}
+.form-error{color:var(--accent-red);font-size:0.9em;}
+.grid{display:grid;grid-gap:20px;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));}
+@media(max-width:600px){nav a{display:block;margin:5px 0;}}

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/session.php';
+require_once __DIR__ . '/../lib/db.php';
+require_once __DIR__ . '/../lib/helpers.php';
+require_once __DIR__ . '/_inc/auth_guard.php';
+
+// Stats queries
+$total_products = (int)db()->query('SELECT COUNT(*) FROM products')->fetchColumn();
+$active_products = (int)db()->query('SELECT COUNT(*) FROM products WHERE is_active=1')->fetchColumn();
+$total_inquiries = (int)db()->query('SELECT COUNT(*) FROM inquiries')->fetchColumn();
+$new_inquiries = (int)db()->query("SELECT COUNT(*) FROM inquiries WHERE status='new'")->fetchColumn();
+
+$latest_inquiries = db()->query('SELECT name,source,created_at,status FROM inquiries ORDER BY created_at DESC LIMIT 5')->fetchAll();
+$latest_products = db()->query('SELECT title,is_active,created_at FROM products ORDER BY created_at DESC LIMIT 5')->fetchAll();
+
+include __DIR__ . '/_inc/header.php';
+?>
+<h2>Dashboard</h2>
+<div class="grid">
+    <div class="card">Total Products<br><strong><?php echo $total_products; ?></strong></div>
+    <div class="card">Active Products<br><strong><?php echo $active_products; ?></strong></div>
+    <div class="card">Total Inquiries<br><strong><?php echo $total_inquiries; ?></strong></div>
+    <div class="card">New Inquiries<br><strong><?php echo $new_inquiries; ?></strong></div>
+</div>
+<div class="card">
+    <h3>Latest Inquiries</h3>
+    <table class="table">
+        <tr><th>Name</th><th>Source</th><th>Date</th><th>Status</th></tr>
+        <?php foreach ($latest_inquiries as $inq): ?>
+        <tr>
+            <td><?php echo e($inq['name']); ?></td>
+            <td><?php echo e($inq['source']); ?></td>
+            <td><?php echo e($inq['created_at']); ?></td>
+            <td><?php echo e($inq['status']); ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+    <a href="/admin/inquiries/list.php">View all inquiries</a>
+</div>
+<div class="card">
+    <h3>Latest Products</h3>
+    <table class="table">
+        <tr><th>Title</th><th>Active</th><th>Created</th></tr>
+        <?php foreach ($latest_products as $p): ?>
+        <tr>
+            <td><?php echo e($p['title']); ?></td>
+            <td><?php echo $p['is_active'] ? 'Yes' : 'No'; ?></td>
+            <td><?php echo e($p['created_at']); ?></td>
+        </tr>
+        <?php endforeach; ?>
+    </table>
+    <a href="/admin/products/list.php">View all products</a>
+</div>
+<?php include __DIR__ . '/_inc/footer.php';

--- a/admin/inquiries/list.php
+++ b/admin/inquiries/list.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+$page = max(1,(int)get('page',1));
+$per=10; $offset=($page-1)*$per;
+$search = get('q');
+$status = get('status','');
+$source = get('source','');
+
+$conds=[];$params=[];
+if($search){ $conds[]='(i.name LIKE ? OR i.email LIKE ? OR i.phone LIKE ?)'; $params=array_merge($params,array_fill(0,3,'%'.$search.'%')); }
+if($status){ $conds[]='i.status=?'; $params[]=$status; }
+if($source){ $conds[]='i.source=?'; $params[]=$source; }
+$where = $conds ? 'WHERE '.implode(' AND ',$conds) : '';
+
+$totalStmt=db()->prepare("SELECT COUNT(*) FROM inquiries i $where");$totalStmt->execute($params);$total=(int)$totalStmt->fetchColumn();$total_pages=max(1,(int)ceil($total/$per));
+
+$listStmt=db()->prepare("SELECT i.*,p.title as product_title FROM inquiries i LEFT JOIN products p ON p.id=i.product_id $where ORDER BY i.created_at DESC LIMIT $per OFFSET $offset");
+$listStmt->execute($params);
+$inquiries=$listStmt->fetchAll();
+
+include __DIR__ . '/../_inc/header.php';
+?>
+<h2>Inquiries</h2>
+<form method="get" class="card">
+    <input type="text" name="q" placeholder="Search" value="<?php echo e($search); ?>">
+    <select name="status">
+        <option value="" <?php if($status==='') echo 'selected';?>>All Status</option>
+        <option value="new" <?php if($status==='new') echo 'selected';?>>New</option>
+        <option value="in_progress" <?php if($status==='in_progress') echo 'selected';?>>In Progress</option>
+        <option value="closed" <?php if($status==='closed') echo 'selected';?>>Closed</option>
+    </select>
+    <select name="source">
+        <option value="" <?php if($source==='') echo 'selected';?>>All Sources</option>
+        <option value="contact" <?php if($source==='contact') echo 'selected';?>>Contact</option>
+        <option value="product" <?php if($source==='product') echo 'selected';?>>Product</option>
+        <option value="other" <?php if($source==='other') echo 'selected';?>>Other</option>
+    </select>
+    <button type="submit">Filter</button>
+</form>
+<table class="table">
+<tr><th>Name</th><th>Source</th><th>Product</th><th>Created</th><th>Status</th><th>Actions</th></tr>
+<?php foreach($inquiries as $i): ?>
+<tr>
+    <td><?php echo e($i['name']); ?></td>
+    <td><?php echo e($i['source']); ?></td>
+    <td><?php echo e($i['product_title']); ?></td>
+    <td><?php echo e($i['created_at']); ?></td>
+    <td><?php echo e($i['status']); ?></td>
+    <td><a href="view.php?id=<?php echo $i['id']; ?>">View</a></td>
+</tr>
+<?php endforeach; ?>
+</table>
+<div>
+<?php for($p=1;$p<=$total_pages;$p++): ?>
+<a href="?page=<?php echo $p; ?>&q=<?php echo e($search); ?>&status=<?php echo e($status); ?>&source=<?php echo e($source); ?>" <?php if($page==$p) echo 'style="font-weight:bold"';?>><?php echo $p; ?></a>
+<?php endfor; ?>
+</div>
+<?php include __DIR__ . '/../_inc/footer.php';

--- a/admin/inquiries/update_status.php
+++ b/admin/inquiries/update_status.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+if($_SERVER['REQUEST_METHOD']!=='POST'){ redirect('list.php'); }
+verify_csrf();
+$id=(int)input('id');
+$status=input('status');
+if($id && in_array($status,['new','in_progress','closed'])){
+    $stmt=db()->prepare('UPDATE inquiries SET status=? WHERE id=?');
+    $stmt->execute([$status,$id]);
+    flash_set('success','Status updated');
+    redirect('view.php?id='.$id);
+}
+redirect('list.php');

--- a/admin/inquiries/view.php
+++ b/admin/inquiries/view.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+$id=(int)get('id');
+$stmt=db()->prepare('SELECT i.*,p.title as product_title FROM inquiries i LEFT JOIN products p ON p.id=i.product_id WHERE i.id=?');
+$stmt->execute([$id]);
+$inq=$stmt->fetch();
+if(!$inq){ redirect('list.php'); }
+
+include __DIR__ . '/../_inc/header.php';
+?>
+<h2>Inquiry View</h2>
+<?php if($msg=flash_get("success")) echo "<p class=\"card\">$msg</p>"; ?>
+<div class="card">
+<p><strong>Name:</strong> <?php echo e($inq['name']); ?></p>
+<p><strong>Email:</strong> <?php echo e($inq['email']); ?></p>
+<p><strong>Phone:</strong> <?php echo e($inq['phone']); ?></p>
+<p><strong>Source:</strong> <?php echo e($inq['source']); ?></p>
+<?php if($inq['product_title']): ?><p><strong>Product:</strong> <?php echo e($inq['product_title']); ?></p><?php endif; ?>
+<p><strong>Message:</strong><br><?php echo nl2br(e($inq['message'])); ?></p>
+<p><strong>Status:</strong> <?php echo e($inq['status']); ?></p>
+<form method="post" action="update_status.php">
+    <?php echo csrf_field(); ?>
+    <input type="hidden" name="id" value="<?php echo $inq['id']; ?>">
+    <select name="status">
+        <option value="new" <?php if($inq['status']==='new') echo 'selected';?>>New</option>
+        <option value="in_progress" <?php if($inq['status']==='in_progress') echo 'selected';?>>In Progress</option>
+        <option value="closed" <?php if($inq['status']==='closed') echo 'selected';?>>Closed</option>
+    </select>
+    <button type="submit">Update Status</button>
+</form>
+<a href="list.php">&larr; Back to list</a>
+</div>
+<?php include __DIR__ . '/../_inc/footer.php';

--- a/admin/login.php
+++ b/admin/login.php
@@ -1,0 +1,76 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/session.php';
+require_once __DIR__ . '/../lib/db.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
+start_app_session();
+
+if (!empty($_SESSION['admin'])) {
+    redirect('/admin/index.php');
+}
+
+$error = '';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    verify_csrf();
+    $email = strtolower(input('email'));
+    $password = input('password');
+    $remember = input('remember');
+
+    $ip = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
+    $key = $email . '|' . $ip;
+    $attempts = $_SESSION['login_attempts'][$key] ?? [];
+    $attempts = array_filter($attempts, fn($ts) => $ts > time() - 900);
+    if (count($attempts) >= 5) {
+        $error = 'Too many failed attempts. Please try again later.';
+    } else {
+        $stmt = db()->prepare('SELECT id,name,email,password_hash FROM admins WHERE email = ?');
+        $stmt->execute([$email]);
+        $admin = $stmt->fetch();
+        if ($admin && password_verify($password, $admin['password_hash'])) {
+            $_SESSION['login_attempts'][$key] = [];
+            $stmt = db()->prepare('UPDATE admins SET last_login_at=NOW() WHERE id=?');
+            $stmt->execute([$admin['id']]);
+            $_SESSION['admin'] = ['id'=>$admin['id'],'name'=>$admin['name'],'email'=>$admin['email']];
+            if ($remember && !empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+                setcookie(session_name(), session_id(), time()+86400*30, '/', '', true, true);
+            }
+            redirect('/admin/index.php');
+        } else {
+            $attempts[] = time();
+            $_SESSION['login_attempts'][$key] = $attempts;
+            $error = 'Invalid email or password.';
+        }
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Admin Login</title>
+    <link rel="stylesheet" href="/admin/assets/admin.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+</head>
+<body>
+<div style="max-width:400px;margin:80px auto;" class="card">
+    <h2>Admin Login</h2>
+    <?php if ($error): ?><p class="form-error"><?php echo e($error); ?></p><?php endif; ?>
+    <form method="post">
+        <?php echo csrf_field(); ?>
+        <label>Email
+            <input type="email" name="email" value="<?php echo e(input('email')); ?>" required>
+        </label>
+        <label>Password
+            <input type="password" name="password" required>
+        </label>
+        <label><input type="checkbox" name="remember" value="1"> Remember me</label>
+        <input type="submit" value="Login">
+    </form>
+</div>
+</body>
+</html>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../config.php';
+require_once __DIR__ . '/../lib/session.php';
+require_once __DIR__ . '/../lib/helpers.php';
+
+start_app_session();
+
+$_SESSION = [];
+if (ini_get('session.use_cookies')) {
+    $params = session_get_cookie_params();
+    setcookie(session_name(), '', time() - 42000, $params['path'], $params['domain'], $params['secure'], $params['httponly']);
+}
+session_destroy();
+setcookie('remember', '', time() - 3600, '/');
+redirect('/admin/login.php');

--- a/admin/products/create.php
+++ b/admin/products/create.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+$errors = [];
+$cats = db()->query('SELECT id,name FROM categories WHERE is_active=1 ORDER BY name')->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+    verify_csrf();
+    $title = input('title');
+    $slug = input('slug');
+    $slug = $slug ? slugify($slug) : slugify($title);
+    // ensure unique slug
+    $slug = unique_slug($slug);
+    $sku = input('sku');
+    $category_id = (int)input('category_id');
+    $price = (float)input('price');
+    $sale_price = (float)input('sale_price');
+    $short_desc = input('short_desc');
+    $description = input('description');
+    $is_active = input('is_active') ? 1 : 0;
+    $is_featured = input('is_featured') ? 1 : 0;
+    $meta_title = input('meta_title');
+    $meta_desc = input('meta_desc');
+    $images = [input('image1'),input('image2'),input('image3')];
+
+    if ($title==='') $errors['title']='Title required';
+    if (strlen($short_desc)>300) $errors['short_desc']='Short description too long';
+
+    if (!$errors) {
+        $stmt = db()->prepare('INSERT INTO products (title,slug,sku,category_id,price,sale_price,short_desc,description,is_active,is_featured,meta_title,meta_desc) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)');
+        $stmt->execute([$title,$slug,$sku,$category_id,$price,$sale_price,$short_desc,$description,$is_active,$is_featured,$meta_title,$meta_desc]);
+        $pid = (int)db()->lastInsertId();
+        $i=1;
+        foreach ($images as $url) {
+            if ($url) {
+                $stmt2=db()->prepare('INSERT INTO product_images (product_id,url,sort_order) VALUES (?,?,?)');
+                $stmt2->execute([$pid,$url,$i]);
+            }
+            $i++;
+        }
+        flash_set('success','Product created');
+        redirect('list.php');
+    }
+}
+
+function old($key){ return e(input($key)); }
+
+include __DIR__ . '/../_inc/header.php';
+?>
+<h2>Create Product</h2>
+<form method="post" class="card">
+    <?php echo csrf_field(); ?>
+    <label>Title
+        <input type="text" name="title" value="<?php echo old('title'); ?>" required>
+        <?php if(!empty($errors['title'])) echo '<div class="form-error">'.e($errors['title']).'</div>'; ?>
+    </label>
+    <label>Slug
+        <input type="text" name="slug" value="<?php echo old('slug'); ?>">
+    </label>
+    <label>SKU
+        <input type="text" name="sku" value="<?php echo old('sku'); ?>">
+    </label>
+    <label>Category
+        <select name="category_id">
+            <?php foreach($cats as $c): ?>
+            <option value="<?php echo $c['id']; ?>" <?php if((int)input('category_id')==$c['id']) echo 'selected';?>><?php echo e($c['name']); ?></option>
+            <?php endforeach; ?>
+        </select>
+    </label>
+    <label>Price
+        <input type="text" name="price" value="<?php echo old('price'); ?>">
+    </label>
+    <label>Sale Price
+        <input type="text" name="sale_price" value="<?php echo old('sale_price'); ?>">
+    </label>
+    <label>Short Description
+        <textarea name="short_desc" maxlength="300"><?php echo old('short_desc'); ?></textarea>
+        <?php if(!empty($errors['short_desc'])) echo '<div class="form-error">'.e($errors['short_desc']).'</div>'; ?>
+    </label>
+    <label>Description
+        <textarea name="description"><?php echo old('description'); ?></textarea>
+    </label>
+    <label><input type="checkbox" name="is_active" value="1" <?php if(input('is_active')) echo 'checked';?>> Active</label>
+    <label><input type="checkbox" name="is_featured" value="1" <?php if(input('is_featured')) echo 'checked';?>> Featured</label>
+    <label>Meta Title
+        <input type="text" name="meta_title" value="<?php echo old('meta_title'); ?>">
+    </label>
+    <label>Meta Description
+        <textarea name="meta_desc"><?php echo old('meta_desc'); ?></textarea>
+    </label>
+    <label>Image URL 1
+        <input type="text" name="image1" value="<?php echo old('image1'); ?>">
+    </label>
+    <label>Image URL 2
+        <input type="text" name="image2" value="<?php echo old('image2'); ?>">
+    </label>
+    <label>Image URL 3
+        <input type="text" name="image3" value="<?php echo old('image3'); ?>">
+    </label>
+    <input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../_inc/footer.php';
+
+function unique_slug(string $slug, int $exclude_id=0): string {
+    $base = $slug; $i=1;
+    while(true){
+        $params=[$slug];
+        $sql='SELECT COUNT(*) FROM products WHERE slug=?';
+        if($exclude_id){$sql.=' AND id<>?';$params[]=$exclude_id;}
+        $stmt=db()->prepare($sql);
+        $stmt->execute($params);
+        if($stmt->fetchColumn()==0) break;
+        $slug = $base.'-'.$i; $i++;
+    }
+    return $slug;
+}

--- a/admin/products/delete.php
+++ b/admin/products/delete.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    redirect('list.php');
+}
+
+verify_csrf();
+$id = (int)input('id');
+if ($id) {
+    $stmt = db()->prepare('DELETE FROM products WHERE id=?');
+    $stmt->execute([$id]);
+    flash_set('success','Product deleted');
+}
+redirect('list.php');

--- a/admin/products/edit.php
+++ b/admin/products/edit.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+$id = (int)get('id');
+$stmt = db()->prepare('SELECT * FROM products WHERE id=?');
+$stmt->execute([$id]);
+$product = $stmt->fetch();
+if (!$product) { redirect('list.php'); }
+
+$images = db()->prepare('SELECT url FROM product_images WHERE product_id=? ORDER BY sort_order LIMIT 3');
+$images->execute([$id]);
+$image_urls = array_column($images->fetchAll(), 'url');
+$image_urls += [null,null,null];
+
+$errors=[];
+$cats = db()->query('SELECT id,name FROM categories WHERE is_active=1 ORDER BY name')->fetchAll();
+
+if ($_SERVER['REQUEST_METHOD']==='POST') {
+    verify_csrf();
+    $title = input('title');
+    $slug = input('slug');
+    $slug = $slug ? slugify($slug) : slugify($title);
+    $slug = unique_slug($slug,$id);
+    $sku = input('sku');
+    $category_id = (int)input('category_id');
+    $price = (float)input('price');
+    $sale_price = (float)input('sale_price');
+    $short_desc = input('short_desc');
+    $description = input('description');
+    $is_active = input('is_active') ? 1 : 0;
+    $is_featured = input('is_featured') ? 1 : 0;
+    $meta_title = input('meta_title');
+    $meta_desc = input('meta_desc');
+    $images = [input('image1'),input('image2'),input('image3')];
+
+    if ($title==='') $errors['title']='Title required';
+    if (strlen($short_desc)>300) $errors['short_desc']='Short description too long';
+
+    if (!$errors) {
+        $stmt=db()->prepare('UPDATE products SET title=?,slug=?,sku=?,category_id=?,price=?,sale_price=?,short_desc=?,description=?,is_active=?,is_featured=?,meta_title=?,meta_desc=? WHERE id=?');
+        $stmt->execute([$title,$slug,$sku,$category_id,$price,$sale_price,$short_desc,$description,$is_active,$is_featured,$meta_title,$meta_desc,$id]);
+        db()->prepare('DELETE FROM product_images WHERE product_id=?')->execute([$id]);
+        $i=1; foreach($images as $url){ if($url){ db()->prepare('INSERT INTO product_images (product_id,url,sort_order) VALUES (?,?,?)')->execute([$id,$url,$i]); } $i++; }
+        flash_set('success','Product updated');
+        redirect('list.php');
+    }
+} else {
+    // populate defaults
+    $_POST = $product;
+    $_POST['image1']=$image_urls[0];
+    $_POST['image2']=$image_urls[1];
+    $_POST['image3']=$image_urls[2];
+}
+
+function old($key){ return e(input($key)); }
+
+include __DIR__ . '/../_inc/header.php';
+?>
+<h2>Edit Product</h2>
+<form method="post" class="card">
+<?php echo csrf_field(); ?>
+<label>Title
+<input type="text" name="title" value="<?php echo old('title'); ?>" required>
+<?php if(!empty($errors['title'])) echo '<div class="form-error">'.e($errors['title']).'</div>'; ?>
+</label>
+<label>Slug
+<input type="text" name="slug" value="<?php echo old('slug'); ?>">
+</label>
+<label>SKU
+<input type="text" name="sku" value="<?php echo old('sku'); ?>">
+</label>
+<label>Category
+<select name="category_id">
+<?php foreach($cats as $c): ?>
+<option value="<?php echo $c['id']; ?>" <?php if((int)input('category_id')==$c['id']) echo 'selected';?>><?php echo e($c['name']); ?></option>
+<?php endforeach; ?>
+</select>
+</label>
+<label>Price
+<input type="text" name="price" value="<?php echo old('price'); ?>">
+</label>
+<label>Sale Price
+<input type="text" name="sale_price" value="<?php echo old('sale_price'); ?>">
+</label>
+<label>Short Description
+<textarea name="short_desc" maxlength="300"><?php echo old('short_desc'); ?></textarea>
+<?php if(!empty($errors['short_desc'])) echo '<div class="form-error">'.e($errors['short_desc']).'</div>'; ?>
+</label>
+<label>Description
+<textarea name="description"><?php echo old('description'); ?></textarea>
+</label>
+<label><input type="checkbox" name="is_active" value="1" <?php if(input('is_active')) echo 'checked';?>> Active</label>
+<label><input type="checkbox" name="is_featured" value="1" <?php if(input('is_featured')) echo 'checked';?>> Featured</label>
+<label>Meta Title
+<input type="text" name="meta_title" value="<?php echo old('meta_title'); ?>">
+</label>
+<label>Meta Description
+<textarea name="meta_desc"><?php echo old('meta_desc'); ?></textarea>
+</label>
+<label>Image URL 1
+<input type="text" name="image1" value="<?php echo old('image1'); ?>">
+</label>
+<label>Image URL 2
+<input type="text" name="image2" value="<?php echo old('image2'); ?>">
+</label>
+<label>Image URL 3
+<input type="text" name="image3" value="<?php echo old('image3'); ?>">
+</label>
+<input type="submit" value="Save">
+</form>
+<?php include __DIR__ . '/../_inc/footer.php';
+
+function unique_slug(string $slug, int $exclude_id=0): string {
+    $base=$slug;$i=1;
+    while(true){
+        $params=[$slug];
+        $sql='SELECT COUNT(*) FROM products WHERE slug=?';
+        if($exclude_id){$sql.=' AND id<>?';$params[]=$exclude_id;}
+        $stmt=db()->prepare($sql);$stmt->execute($params);
+        if($stmt->fetchColumn()==0) break;
+        $slug=$base.'-'.$i;$i++;
+    }
+    return $slug;
+}

--- a/admin/products/list.php
+++ b/admin/products/list.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+require_once __DIR__ . '/../../config.php';
+require_once __DIR__ . '/../../lib/session.php';
+require_once __DIR__ . '/../../lib/db.php';
+require_once __DIR__ . '/../../lib/helpers.php';
+require_once __DIR__ . '/../_inc/auth_guard.php';
+
+$page = max(1, (int)get('page',1));
+$per = 10;
+$offset = ($page-1)*$per;
+
+$search = get('q');
+$status = get('status','all');
+$category_id = (int)get('category_id');
+$sort = get('sort','created_desc');
+$sorts = ['created_desc'=>'p.created_at DESC','created_asc'=>'p.created_at ASC'];
+$order = $sorts[$sort] ?? $sorts['created_desc'];
+
+$conds = [];$params=[];
+if ($search) {
+    $conds[] = '(p.title LIKE ? OR p.sku LIKE ? OR p.short_desc LIKE ?)';
+    $params = array_merge($params, array_fill(0,3,'%'.$search.'%'));
+}
+if ($category_id) { $conds[]='p.category_id=?'; $params[]=$category_id; }
+if ($status==='active') { $conds[]='p.is_active=1'; }
+$where = $conds ? 'WHERE '.implode(' AND ',$conds) : '';
+
+$totalStmt = db()->prepare("SELECT COUNT(*) FROM products p $where");
+$totalStmt->execute($params);
+$total = (int)$totalStmt->fetchColumn();
+$total_pages = max(1, (int)ceil($total/$per));
+
+$listStmt = db()->prepare("SELECT p.*,c.name AS category_name FROM products p LEFT JOIN categories c ON c.id=p.category_id $where ORDER BY $order LIMIT $per OFFSET $offset");
+$listStmt->execute($params);
+$products = $listStmt->fetchAll();
+
+$cats = db()->query('SELECT id,name FROM categories WHERE is_active=1 ORDER BY name')->fetchAll();
+
+include __DIR__ . '/../_inc/header.php';
+?>
+<h2>Products</h2>
+<?php if($msg=flash_get("success")) echo "<p class=\"card\">$msg</p>"; ?>
+<a href="create.php" class="button">Create Product</a>
+<form method="get" style="margin-top:20px;" class="card">
+    <input type="text" name="q" placeholder="Search" value="<?php echo e($search); ?>">
+    <select name="category_id">
+        <option value="0">All Categories</option>
+        <?php foreach ($cats as $c): ?>
+            <option value="<?php echo $c['id']; ?>" <?php if($category_id==$c['id']) echo 'selected';?>><?php echo e($c['name']); ?></option>
+        <?php endforeach; ?>
+    </select>
+    <select name="status">
+        <option value="all" <?php if($status==='all') echo 'selected';?>>All</option>
+        <option value="active" <?php if($status==='active') echo 'selected';?>>Active</option>
+    </select>
+    <select name="sort">
+        <option value="created_desc" <?php if($sort==='created_desc') echo 'selected';?>>Newest</option>
+        <option value="created_asc" <?php if($sort==='created_asc') echo 'selected';?>>Oldest</option>
+    </select>
+    <button type="submit">Filter</button>
+</form>
+<table class="table">
+<tr><th>Title</th><th>Category</th><th>Price</th><th>Active</th><th>Featured</th><th>Created</th><th>Actions</th></tr>
+<?php foreach ($products as $p): ?>
+<tr>
+    <td><?php echo e($p['title']); ?></td>
+    <td><?php echo e($p['category_name']); ?></td>
+    <td><?php echo e($p['price']); ?></td>
+    <td><?php echo $p['is_active'] ? 'Yes':'No'; ?></td>
+    <td><?php echo $p['is_featured'] ? 'Yes':'No'; ?></td>
+    <td><?php echo e($p['created_at']); ?></td>
+    <td>
+        <a href="edit.php?id=<?php echo $p['id']; ?>">Edit</a>
+        <form action="delete.php" method="post" style="display:inline;" onsubmit="return confirm('Delete?');">
+            <?php echo csrf_field(); ?>
+            <input type="hidden" name="id" value="<?php echo $p['id']; ?>">
+            <button type="submit">Delete</button>
+        </form>
+    </td>
+</tr>
+<?php endforeach; ?>
+</table>
+<div>
+<?php for($i=1;$i<=$total_pages;$i++): ?>
+    <a href="?page=<?php echo $i; ?>&q=<?php echo e($search); ?>&status=<?php echo e($status); ?>&category_id=<?php echo $category_id; ?>&sort=<?php echo e($sort); ?>" <?php if($page==$i) echo 'style="font-weight:bold"';?>><?php echo $i; ?></a>
+<?php endfor; ?>
+</div>
+<?php include __DIR__ . '/../_inc/footer.php';

--- a/lib/helpers.php
+++ b/lib/helpers.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types=1);
+
+require_once __DIR__ . '/session.php';
+
+/** Escape HTML entities */
+function e(string $v): string
+{
+    return htmlspecialchars($v, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+}
+
+/** Generate or retrieve CSRF token */
+function csrf_token(): string
+{
+    start_app_session();
+    if (empty($_SESSION[CSRF_TOKEN_KEY])) {
+        $_SESSION[CSRF_TOKEN_KEY] = bin2hex(random_bytes(32));
+    }
+    return $_SESSION[CSRF_TOKEN_KEY];
+}
+
+/** Return hidden CSRF field */
+function csrf_field(): string
+{
+    return '<input type="hidden" name="_token" value="' . e(csrf_token()) . '">';
+}
+
+/** Verify CSRF token on POST requests */
+function verify_csrf(): void
+{
+    start_app_session();
+    $token = $_POST['_token'] ?? '';
+    if (!$token || !hash_equals($_SESSION[CSRF_TOKEN_KEY] ?? '', $token)) {
+        http_response_code(419);
+        echo 'Page expired. Please go back and try again.';
+        exit;
+    }
+}
+
+/** Redirect helper */
+function redirect(string $path): void
+{
+    header('Location: ' . $path);
+    exit;
+}
+
+/** Flash message helpers */
+function flash_set(string $type, string $msg): void
+{
+    start_app_session();
+    $_SESSION['flash'][$type][] = $msg;
+}
+
+function flash_get(string $type): ?string
+{
+    start_app_session();
+    if (empty($_SESSION['flash'][$type])) {
+        return null;
+    }
+    $msgs = $_SESSION['flash'][$type];
+    unset($_SESSION['flash'][$type]);
+    return implode('<br>', array_map('e', $msgs));
+}
+
+/** Safe input helpers */
+function input(string $key, $default = '')
+{
+    return isset($_POST[$key]) ? trim((string)$_POST[$key]) : $default;
+}
+
+function get(string $key, $default = '')
+{
+    return isset($_GET[$key]) ? trim((string)$_GET[$key]) : $default;
+}
+
+/** Slugify utility */
+function slugify(string $text): string
+{
+    $text = strtolower($text);
+    $text = preg_replace('/[^a-z0-9]+/i', '-', $text);
+    $text = trim($text, '-');
+    return $text ?: 'n-a';
+}


### PR DESCRIPTION
## Summary
- Add helper utilities for HTML escaping, CSRF, flash messages and input handling
- Implement admin authentication with throttling and dashboard stats
- Provide product and inquiry management with create/edit/delete and status updates
- Include change password page and lightweight admin CSS and layout

## Testing
- `find admin lib -name '*.php' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_689b22c090808332a2c513f51a5aa8f6