### PR TITLE
Fix admin logout redirect and environment DB config

### DIFF
--- a/admin/includes/config.php
+++ b/admin/includes/config.php
@@ -1,8 +1,29 @@
 <?php
-$host = $_SERVER['HTTP_HOST'] ?? '';
-if ($host === 'localhost' || $host === '127.0.0.1') {
+// Environment-aware configuration for base URL and database credentials
+
+$serverHost = $_SERVER['HTTP_HOST'] ?? '';
+
+if ($serverHost === 'localhost' || $serverHost === '127.0.0.1') {
+    // Local development settings
     $BASE_URL = '/iswift/';
+
+    $DB_HOST = 'localhost';
+    $DB_NAME = 'iswift_db';
+    $DB_USER = 'root';
+    $DB_PASS = '';
 } else {
+    // Production settings
     $BASE_URL = '/';
+
+    $DB_HOST = 'localhost';
+    $DB_NAME = 'u348991914_iswift';
+    $DB_USER = 'u348991914_iswift';
+    $DB_PASS = 'Z@q@@Fu|fQ$3';
 }
+
+// Define constants for broader compatibility
+if (!defined('DB_HOST')) define('DB_HOST', $DB_HOST);
+if (!defined('DB_NAME')) define('DB_NAME', $DB_NAME);
+if (!defined('DB_USER')) define('DB_USER', $DB_USER);
+if (!defined('DB_PASS')) define('DB_PASS', $DB_PASS);
 ?>

--- a/admin/includes/db.php
+++ b/admin/includes/db.php
@@ -1,11 +1,18 @@
 <?php
-$host = 'localhost';
-$db   = 'u348991914_iswift';
-$user = 'u348991914_iswift';
-$pass = 'Z@q@@Fu|fQ$3'; // Replace with actual
+// Database connection using environment-specific configuration
+
+// Ensure configuration is loaded for DB credentials
+if (!isset($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME)) {
+    require_once __DIR__ . '/config.php';
+}
+
+$host = $DB_HOST ?? 'localhost';
+$db   = $DB_NAME ?? '';
+$user = $DB_USER ?? '';
+$pass = $DB_PASS ?? '';
 
 $conn = new mysqli($host, $user, $pass, $db);
 if ($conn->connect_error) {
-    die("Connection failed: " . $conn->connect_error);
+    die('Connection failed: ' . $conn->connect_error);
 }
 ?>

--- a/admin/logout.php
+++ b/admin/logout.php
@@ -12,7 +12,7 @@ include __DIR__ . '/includes/config.php';
   <title>Logged Out – iSwift ERP</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
-  <meta http-equiv="refresh" content="2;url=<?= $BASE_URL ?>login.php">
+  <meta http-equiv="refresh" content="2;url=<?= $BASE_URL ?>admin/index.php">
   <link rel="stylesheet" href="<?= $BASE_URL ?>admin/assets/style.css">
 </head>
 <body class="logout-page">


### PR DESCRIPTION
## Summary
- redirect admin logout to admin index
- configure base URL and DB credentials per environment
- connect DB using env-aware config

## Testing
- `php -l admin/includes/config.php`
- `php -l admin/includes/db.php`
- `php -l admin/logout.php`


------
https://chatgpt.com/codex/tasks/task_e_689d240d7c708332aae2e7a3c5625d8b